### PR TITLE
Add Viewport Scaling by Aspect Ratio

### DIFF
--- a/nanoarch.go
+++ b/nanoarch.go
@@ -123,6 +123,13 @@ func videoSetPixelFormat(format uint32) C.bool {
 	return true
 }
 
+/**
+ * When resizing the window, resize the content.
+ */
+func resizedFramebuffer(w *glfw.Window, width int, height int) {
+	gl.Viewport(0, 0, int32(width), int32(height));
+}
+
 func createWindow(width int, height int) {
 	glfw.WindowHint(glfw.Resizable, glfw.False)
 	glfw.WindowHint(glfw.ContextVersionMajor, 4)
@@ -137,6 +144,12 @@ func createWindow(width int, height int) {
 	}
 
 	window.MakeContextCurrent()
+
+	// Force the same aspect ratio.
+	window.SetAspectRatio(width, height)
+
+	// When resizing the window, also resize the content.
+	window.SetFramebufferSizeCallback(resizedFramebuffer)
 
 	// Initialize Glow
 	if err := gl.Init(); err != nil {


### PR DESCRIPTION
This will make it so that when you resize the window, the viewport will scale with the content accordingly. Also forces the same aspect ratio on the window so that the content doesn't distort.

Can now resize Mario and have it scale correctly...

![screenshot at 2018-04-27 08-03-31](https://user-images.githubusercontent.com/25086/39361676-874b1cd2-49f1-11e8-934e-8a9505079441.png)
